### PR TITLE
修复与分离组件

### DIFF
--- a/src/components/layout/BackTop.vue
+++ b/src/components/layout/BackTop.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="backTop"
+       :style="{ right: right + 'px', bottom: bottom + 'px' }"
+       v-if="showBackTop">
+    <i class="iconfont icon-top"
+       :style="{ fontSize: fontSize + 'px'}"
+       @click="backTop"></i>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'BackTop',
+  props: {
+    right: {
+      type: Number,
+      default: 50,
+    },
+    bottom: {
+      type: Number,
+      default: 50,
+    },
+    fontSize: {
+      type: Number,
+      default: 18,
+    },
+  },
+  data() {
+    return {
+      targetDom: null, // 当前滚动对象
+      showBackTop: false, // 是否显示回到顶部标识
+      scrollY: 0, // 滚动距离
+    }
+  },
+  mounted() {
+    // 监听页面滚动
+    window.addEventListener('scroll', this.handleScroll, true)
+  },
+  methods: {
+    handleScroll(e) {
+      this.scrollY = e.target.scrollTop
+      this.showBackTop = e.target.scrollTop > 100 // 页面滚动距离大于100的时候显示回到top的标识
+      this.targetDom = e
+    },
+    // 滑动到顶部
+    backTop() {
+      const _this = this
+      let timer = requestAnimationFrame(function fn() {
+        const currentTop = _this.targetDom.target.scrollTop
+        if (currentTop > 0) {
+          // 平滑滚动
+          const scrollSpeed = currentTop + ((0 - currentTop) / 6)
+          _this.targetDom.target.scrollTop = scrollSpeed
+          timer = requestAnimationFrame(fn)
+        } else {
+          cancelAnimationFrame(timer)
+        }
+      })
+    },
+  },
+  destroyed() {
+    window.removeEventListener('scroll', this.handleScroll)
+  },
+}
+
+</script>
+<style type="text/scss" lang='scss' scoped>
+.backTop {
+  position: fixed;
+  display: inline-block;
+  text-align: center;
+  cursor: pointer;
+  width: 40px;
+  height: 40px;
+  border-radius: 4px;
+  line-height: 45px;
+  z-index: 3;
+}
+</style>

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -4,5 +4,6 @@ import AppMain from './AppMain'
 import ReuseTab from './ReuseTab'
 import ScrollBar from './ScrollBar'
 import MenuTab from './MenuTab.vue'
+import BackTop from './BackTop.vue'
 
-export { NavBar, SideBar, AppMain, ReuseTab, ScrollBar, MenuTab }
+export { NavBar, SideBar, AppMain, ReuseTab, ScrollBar, MenuTab, BackTop }

--- a/src/views/home/Home.vue
+++ b/src/views/home/Home.vue
@@ -25,11 +25,9 @@
           <app-main ref="appMain"
                     class="app-main"></app-main>
         </el-main>
-        <div class="backTop"
-             v-if="showBackTop">
-          <i class="iconfont icon-top"
-             @click="backTop"></i>
-        </div>
+        <back-top :right="50"
+                  :bottom="50"
+                  :fontSize="24"></back-top>
       </el-container>
     </el-container>
   </div>
@@ -42,6 +40,7 @@ import {
   AppMain,
   ReuseTab,
   MenuTab,
+  BackTop,
 } from '@/components/layout'
 import layoutMixin from 'lin/mixin/layout.js'
 
@@ -61,8 +60,6 @@ export default {
       foldState: false, // 控制左侧菜单栏按键
       upState: false, // 控制历史记录栏按键
       showReuseTab: true, // 是否显示历史记录栏
-      showBackTop: false, // 是否显示回到顶部标识
-      scrollY: 0, // 滚动距离
     }
   },
   mounted() {
@@ -79,8 +76,6 @@ export default {
         _this.isCollapse = false
       }
     }
-    // 监听滑动事件
-    window.addEventListener('scroll', this.handleScroll, true)
   },
   methods: {
     // 控制菜单折叠
@@ -104,18 +99,6 @@ export default {
       this.clientWidth = document.body.clientWidth
       this.$refs.appMain.$el.style.minHeight = `${this.clientHeight - totalHeight}px`
     },
-    // 监听滚轮
-    handleScroll(e) {
-      this.scrollY = e.target.scrollTop
-      this.showBackTop = e.target.scrollTop > 100 // 页面滚动距离大于100的时候显示回到top的标识
-    },
-    // 滑动到顶部
-    backTop() {
-      this.$refs.main.$el.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      })
-    },
   },
   watch: {
     isCollapse() {
@@ -135,9 +118,7 @@ export default {
     AppMain,
     ReuseTab,
     MenuTab,
-  },
-  destroyed() {
-    window.removeEventListener('scroll', this.handleScroll)
+    BackTop,
   },
 }
 </script>
@@ -188,21 +169,5 @@ export default {
   overflow-y: auto;
   position: relative;
   padding-bottom: 0;
-}
-.backTop {
-  position: fixed;
-  display: inline-block;
-  text-align: center;
-  cursor: pointer;
-  right: 30px;
-  bottom: 50px;
-  width: 40px;
-  height: 40px;
-  border-radius: 4px;
-  line-height: 45px;
-  z-index: 3;
-  .iconfont {
-    font-size: 24px;
-  }
 }
 </style>


### PR DESCRIPTION
1.解决返回到顶方法scrollTop在IE10、11、Edge浏览器下报错问题。（IE10、11、Edge对scrollTop方法支持不完整）
2.返回图标大小、位置用户可配置。
3.实现原生模拟smooth返回到顶。