### PR TITLE
style(src\components\layout\User.vue): 工具栏上移时，增加头像上边缘距离浏览器间隙

### DIFF
--- a/src/components/layout/User.vue
+++ b/src/components/layout/User.vue
@@ -367,6 +367,7 @@ export default {
 }
 
 .user {
+  height: 40px;
   .el-dropdown-link {
     cursor: pointer;
 


### PR DESCRIPTION
控制 class 为 user 的类 高度为 40px, 比原来增加了 3px 的间隙