### PR TITLE
build(.eslintrc.js): 去掉'linebreak-style': [0, 'error', 'windows']

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'linebreak-style': [0, 'error', 'windows'],
     'import/extensions': 0, // import不需要写文件扩展名
     'import/no-unresolved': 0,
     // 'import/no-duplicates': 0,


### PR DESCRIPTION
airbnb校验规则会要求项目使用 LF 换行符, git for windows 在默认配置下会将签出的代码转换成 CRLF。此处应要求 windwos 开发者关闭 git 自动转换功能。