### PR TITLE
chore(webpack): 自定义解析文件的扩展名

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -8,7 +8,7 @@ module.exports = {
   lintOnSave: true,
   productionSourceMap: false,
   // assetsDir: 'static',
-  chainWebpack: (config) => {
+  chainWebpack: config => {
     config.resolve.alias
       .set('@', resolve('src'))
       .set('lin', resolve('src/lin'))
@@ -19,13 +19,9 @@ module.exports = {
       .use('vue-loader')
       .loader('vue-loader')
       .end()
-      .use("vue-markdown-loader")
-      .loader('vue-markdown-loader/lib/markdown-compiler')     
-  },
-  configureWebpack: {
-    resolve: {
-      extensions: ['.js', '.json', '.vue', '.scss', '.html'],
-    },
+      .use('vue-markdown-loader')
+      .loader('vue-markdown-loader/lib/markdown-compiler')
+    config.resolve.extensions.store = new Set(['.js', '.json', '.vue', '.scss', '.html'])
   },
   css: {
     loaderOptions: {
@@ -36,7 +32,5 @@ module.exports = {
   },
   devServer: {},
   // node_modules依赖项es6语法未转换问题
-  transpileDependencies: [
-    'vuex-persist',
-  ],
+  transpileDependencies: ['vuex-persist'],
 }


### PR DESCRIPTION
Use command: vue inspect --mode=development > output.js
Before: 
```js
extensions: [
      '.mjs',
      '.js',
      '.jsx',
      '.vue',
      '.json',
      '.wasm',
      '.js',
      '.json',
      '.vue',
      '.scss',
      '.html'
    ]
```

Right Now:
```js
    extensions: [
      '.js',
      '.json',
      '.vue',
      '.scss',
      '.html'
    ]
```