### PR TITLE
fix(upload-imgs):修复 upload-imgs 组件初始化未传 id 字段进行操作报错的 bug

### DIFF
--- a/src/components/base/upload-imgs/index.vue
+++ b/src/components/base/upload-imgs/index.vue
@@ -175,7 +175,7 @@ function createItem(data = null, oldData = {}) {
   }
 
   // 存在id, 说明是传入已存在数据
-  item.id = data.id
+  item.id = data.id || createId()
   item.imgId = data.imgId || item.imgId
   item.src = data.src || item.src
   item.display = data.display || item.display


### PR DESCRIPTION
## upload 图像上传组件初始化数据未传id字段，点击组件的“更换图片”时报错


+ 初始化数据

```
imgInitData: [{
        display:'https://fuss10.elemecdn.com/3/63/4e7f3a15429bfda99bce42a18cdd1jpeg.jpeg?imageMogr2/thumbnail/360x360/format/webp/quality/100'
}]
```

+ 报错信息

```
index.vue?6ced:895 TypeError: Cannot read property 'display' of undefined
    at VueComponent.setImgInfo (index.vue?6ced:911)
    at VueComponent._callee5$ (index.vue?6ced:882)
    at tryCatch (runtime.js?96cf:45)
    at Generator.invoke [as _invoke] (runtime.js?96cf:271)
    at Generator.prototype.<computed> [as next] (runtime.js?96cf:97)
    at asyncGeneratorStep (cjs.js?!./node_modules/babel-loader/lib/index.js!./node_modules/cache-loader/dist/cjs.js?!./node_modules/vue-loader/lib/index.js?!./src/components/base/upload-imgs/index.vue?vue&type=script&lang=js&:7)
    at _next (cjs.js?!./node_modules/babel-loader/lib/index.js!./node_modules/cache-loader/dist/cjs.js?!./node_modules/vue-loader/lib/index.js?!./src/components/base/upload-imgs/index.vue?vue&type=script&lang=js&:9)
```

> 经排查，初始化数据中必须传入id字段，但官方文档中说id为可选初始化字段，否则报以上错误。在创建已存在数据时设置默认 id 即可修复上述 bug