### PR TITLE
fix: api 接口域名修改为 127.0.0.1

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 ENV = 'development'
 
-VUE_APP_BASE_URL = 'http://localhost:5000/'
+VUE_APP_BASE_URL = 'http://127.0.0.1:5000/'

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
 
 
-VUE_APP_BASE_URL = 'http://localhost:5000/'
+VUE_APP_BASE_URL = 'http://127.0.0.1:5000/'


### PR DESCRIPTION
Java 后端在开发环境下时
如果前端访问的是 localhost，access.log 记录到的 ip 会是 ipv6 格式
该 commit 将 api 接口域名从 localhost 修改为 127.0.0.1 以修复此问题