### PR TITLE
fix: 重写Utils.sortByOrder()的实现，解决order负数排序异常的问题

### DIFF
--- a/src/lin/util/util.js
+++ b/src/lin/util/util.js
@@ -94,7 +94,7 @@ function getTypeOf(obj) {
 
 function insertItem(item, arr) {
   const { order } = item
-  if (typeof arr[order] !== 'number') {
+  if (!arr[order]) {
     arr[order] = item
     return
   }


### PR DESCRIPTION
例如：在两个路由里设置了`-3`，先设置的路由会的在`-3`的位置，但后设置的则会在`-2`的位置