### PR TITLE
fix: 部分情况下token已失效，但页面未退出而反复刷新的问题

### DIFF
--- a/src/lin/plugin/axios.js
+++ b/src/lin/plugin/axios.js
@@ -28,7 +28,7 @@ const config = {
  * @param { number } code 错误码
  */
 function refreshTokenException(code) {
-  const codes = [10000, 10042, 10050, 10052]
+  const codes = [10000, 10042, 10050, 10052, 10012]
   return codes.includes(code)
 }
 


### PR DESCRIPTION
多次热更新/多页打开cms而某页定时器未失效出现的未退出登录时就会出现不带请求头刷新token，而反复请求不退出的异常